### PR TITLE
Feature/remove target blank

### DIFF
--- a/admin/class-options-page.php
+++ b/admin/class-options-page.php
@@ -154,6 +154,24 @@ class Options_Page {
 
 					<tr>
 						<th scope="row">
+							<?php _e( 'Additional attributes', 'remove-noreferrer' ); ?>
+						</th>
+						<td>
+							<fieldset>
+								<?php
+									$this->render_checkbox_where_should_the_plugin_work(
+										$options,
+										'target_blank',
+										__( 'Remove target blank', 'remove-noreferrer' )
+									);
+
+								?>
+							</fieldset>
+						</td>
+					</tr>
+
+					<tr>
+						<th scope="row">
 							<?php _e( 'Widgets' ); ?>
 						</th>
 						<td>

--- a/frontend/class-plugin.php
+++ b/frontend/class-plugin.php
@@ -83,7 +83,11 @@ class Plugin extends \Remove_Noreferrer\Base\Plugin {
 			return $content;
 		}
 
-		return $this->remove_noreferrer( $content );
+		$filtered_content = $this->remove_noreferrer( $content );
+		if ( $this->can_remove_target_blank() ) {
+			$filtered_content = $this->remove_target_blank( $filtered_content );
+		}
+		return $filtered_content;
 	}
 
 	/**
@@ -178,6 +182,20 @@ class Plugin extends \Remove_Noreferrer\Base\Plugin {
 	}
 
 	/**
+	 * Checks if the target blank attribute can be removed
+	 *
+	 * @since 2.0.1
+	 * @access private
+	 *
+	 * @return bool
+	 */
+	private function can_remove_target_blank() {
+		$where_should_the_plugin_work = $this->get_option( GRN_WHERE_SHOULD_THE_PLUGIN_WORK_KEY );
+
+		return in_array( 'target_blank', $where_should_the_plugin_work, true );
+	}
+
+	/**
 	 * Return option's value by key
 	 *
 	 * @since 1.1.1
@@ -267,6 +285,19 @@ class Plugin extends \Remove_Noreferrer\Base\Plugin {
 	 */
 	private function remove_noreferrer( $content ) {
 		return $this->_links_processor->call( $content );
+	}
+
+	/**
+	 * Remove target blank attribute from the links
+	 *
+	 * @since 2.0.1
+	 * @access private
+	 *
+	 * @param string $content Content.
+	 * @return string
+	 */
+	private function remove_target_blank( $content ) {
+		return $this->_links_processor->call( $content, 'target' );
 	}
 }
 

--- a/remove-noreferrer.php
+++ b/remove-noreferrer.php
@@ -63,6 +63,7 @@ function grn_allowed_values() {
 		'page',
 		'comments',
 		'text_widget',
+		'target_blank',
 		'custom_html_widget',
 	);
 }

--- a/tests/phpunit/tests/admin/class-options-page-test.php
+++ b/tests/phpunit/tests/admin/class-options-page-test.php
@@ -177,7 +177,7 @@ class Options_Page_Test extends \WP_UnitTestCase {
 
 		preg_match_all( '/<input\s+type="checkbox"\s+name="remove_noreferrer\[where_should_the_plugin_work\]\[\]"[^>]*>/', $content, $matches );
 
-		$this->assertCount( 6, $matches[0] );
+		$this->assertCount( 7, $matches[0] );
 	}
 
 	/**

--- a/tests/phpunit/tests/frontend/class-links-processor-test.php
+++ b/tests/phpunit/tests/frontend/class-links-processor-test.php
@@ -50,11 +50,12 @@ class Links_Processor_Test extends \PHPUnit\Framework\TestCase {
 	 *
 	 * @param string $input The input string.
 	 * @param string $expected The expected function output.
+	 * @param string $attribute_to_remove The attribute to remove.
 	 *
 	 * @return void
 	 */
-	public function test_call( $input, $expected ) {
-		$result = $this->_processor->call( $input );
+	public function test_call( $input, $expected, $attribute_to_remove ) {
+		$result = $this->_processor->call( $input, $attribute_to_remove );
 
 		$this->assertSame( $expected, $result );
 	}
@@ -73,39 +74,89 @@ class Links_Processor_Test extends \PHPUnit\Framework\TestCase {
 			'no links found' => array(
 				'test',
 				'test',
+				'',
 			),
 			'no noreferrer found' => array(
 				'<a rel="nofollow">test</a>',
 				'<a rel="nofollow">test</a>',
+				'',
 			),
 			'noreferrer found' => array(
 				'<a rel="nofollow noreferrer">test</a>',
 				'<a rel="nofollow">test</a>',
+				'',
 			),
 			'rel values inside single quotes' => array(
 				'<a class="test"   rel=\'nofollow noreferrer\' name="test">test</a>',
 				'<a class="test"   rel=\'nofollow\' name="test">test</a>',
+				'',
 			),
 			'link has attributes before rel' => array(
 				'<a class="test"   rel="nofollow noreferrer">test</a>',
 				'<a class="test"   rel="nofollow">test</a>',
+				'',
 			),
 			'link has attributes after rel' => array(
 				'<a rel="nofollow noreferrer" name="test">test</a>',
 				'<a rel="nofollow" name="test">test</a>',
+				'',
 			),
 			'removes extra spaces in rel' => array(
 				'<a rel="  nofollow   noreferrer   ugc ">test</a>',
 				'<a rel="nofollow ugc">test</a>',
+				'',
 			),
 			'two links' => array(
 				'<a rel="nofollow noreferrer">test</a> <a rel="ugc noreferrer nofollow">test2</a>',
 				'<a rel="nofollow">test</a> <a rel="ugc nofollow">test2</a>',
+				'',
 			),
 			'rel="nofollow" exists outside the link' => array(
 				'<a rel="nofollow noreferrer">rel="noreferrer"</a>',
 				'<a rel="nofollow">rel="noreferrer"</a>',
+				'',
 			),
+			'no target blank found' => array(
+				'<a rel="nofollow">test</a>',
+				'<a rel="nofollow">test</a>',
+				'target',
+			),
+			'target blank found' => array(
+				'<a target="_blank">test</a>',
+				'<a target="">test</a>',
+				'target',
+			),
+			'target values inside single quotes' => array(
+				'<a class="test"   target=\'_blank\' name="test">test</a>',
+				'<a class="test"   target=\'\' name="test">test</a>',
+				'target',
+			),
+			'link has attributes before target' => array(
+				'<a class="test"   target="_blank">test</a>',
+				'<a class="test"   target="">test</a>',
+				'target',
+			),
+			'link has attributes after target' => array(
+				'<a target="_blank" name="test">test</a>',
+				'<a target="" name="test">test</a>',
+				'target',
+			),
+			'removes extra spaces in target' => array(
+				'<a target=" _blank  ">test</a>',
+				'<a target="">test</a>',
+				'target',
+			),
+			'target two links' => array(
+				'<a target="_blank">test</a> <a target="_blank">test2</a>',
+				'<a target="">test</a> <a target="">test2</a>',
+				'target',
+			),
+			'target="_blank" exists outside the link' => array(
+				'<a target="_blank">target="_blank"</a>',
+				'<a target="">target="_blank"</a>',
+				'target',
+			),
+
 		);
 		// phpcs:enable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
 	}

--- a/tests/phpunit/tests/remove-noreferrer-test.php
+++ b/tests/phpunit/tests/remove-noreferrer-test.php
@@ -57,6 +57,7 @@ class Remove_Noreferrer_Test extends \WP_UnitTestCase {
 				'page',
 				'comments',
 				'text_widget',
+				'target_blank',
 				'custom_html_widget',
 			),
 			\Remove_Noreferrer\grn_allowed_values()


### PR DESCRIPTION
This PR adds the feature to allow the removal of the target="_blank" attribute from all links.

The user can choose to enable this feature by flagging the option in the settings page.

Tests of the feature are included.